### PR TITLE
Add peach light control and request handling for robot LEDs

### DIFF
--- a/ESP32/add_LEDS_control_to_robot/add_LEDS_control_to_robot.ino
+++ b/ESP32/add_LEDS_control_to_robot/add_LEDS_control_to_robot.ino
@@ -541,6 +541,10 @@ void setup() {
       pixels.show();
     request->send(200, "text/plain", "LED blue");
   });
+  server.on("/lights_peach", HTTP_GET, [](AsyncWebServerRequest *request) {
+    setRGBColor(255, 229, 180);
+    request->send(200, "text/plain", "Lights set to peach");
+  });
 
 
 

--- a/main.py
+++ b/main.py
@@ -237,6 +237,10 @@ def go_to_goal(goal_pos):
 
 
 def get_path_to_target():
+    """
+    Get the path to the current target position.
+    """
+    send_lights_peach_request()
     finished = False
     while not finished:
         streaming_client.update_sync()

--- a/robotCommands.py
+++ b/robotCommands.py
@@ -105,6 +105,13 @@ def send_steer_request(left=250, right = 250):
         # print("STEER request sent. Response:", response.text)
     except Exception as e:
         print("Error sending STEER request:", e)
+        
+def send_lights_peach_request():
+    """Turn the robot RGB LEDs to peach."""
+    try:
+        requests.get(f"{ESPConfig.ESP_IP}/lights_peach")
+    except Exception as e:
+        print("Error sending LIGHTS PEACH request:", e)
 
 def _send_start_beeping_request_raw(on=300, off=300):
     try:

--- a/test_peach_requst.py
+++ b/test_peach_requst.py
@@ -1,0 +1,6 @@
+from robotCommands import *
+from PARAMETERS import *
+
+
+
+send_lights_peach_request()


### PR DESCRIPTION
- Implemented a new endpoint to set the robot's RGB LEDs to peach.
- Added a function to send a request for the peach light setting.
- Created a test script to verify the peach light functionality.